### PR TITLE
Added feature to add remove elements of the exometer metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This reporter pushes data to [InfluxDB](https://influxdb.com/index.html).
         {reporters, [
             {exometer_report_influxdb, [{protocol, http}, 
                                         {host, <<"localhost">>},
-                                        {port, 9090},
+                                        {port, 8086},
                                         {db, <<"exometer">>},
                                         {tags, [{region, ru}]}]}
         ]}
@@ -41,12 +41,11 @@ Available options:
 * __username__ - username for authorization on InfluxDB. __Not implemented yet__.
 * __password__ - password for authorization on InfluxDB. __Not implemented yet__.
 * __timestamping__ - enable timestamping, `false` by default.
-* __tags__ - list of default tags for each data point. Here always is `host` which local host name by default. 
+* __tags__ - list of default tags for each data point. The `host` is automatically included here. 
 
 Timestamping is by default done by influxdb itself. To enable `timestamping` with the reporter you can use `true` or `{true, Precision}` where `Precision` is a unit taken from `[n,u,ms,s,m,h]`. The default unit is `u`.
 
-There is possibility to extend the default tags list which only has `host` by default. 
-When you describe subscriptions list you can add tags to `Extra`. For example:
+Besides the `tags` for the reporter initialization it is possible to add other tags via the `Extra` parameter of `exometer_report:subscribe/5` as done here with environment variables:
 
 ```erlang
 {exometer, 
@@ -54,8 +53,15 @@ When you describe subscriptions list you can add tags to `Extra`. For example:
          {exometer_report_influxdb, [erlang, memory], total, 5000, true, [{tag, <<"value">>}]},
     ]}
 }.
-
 ```
+
+By default the in influxdb visible name of the metric is derived from the exometer id: here `[erlang, memory]` is translated to `erlang_memory`. It is possible to remove an item from this list by naming itself or its position with the `from_name` keyword. A removed element is then used as tag:
+
+```erlang
+exometer_report:subscribe(exometer_report_influxdb, [erlang, memory], total, 5000, true, [{tag, {from_name, 2}}]).
+```
+
+This will result in a name `erlang` with the tag pair `{tag, memory}` (plus the default pair `{host, Host}`).
 
 # TODO
 


### PR DESCRIPTION
id and to add them as tag in the subscription call. Closes #3.

Elements of the exometer id can be removed with the 'from_name'
keyword by using its name or position in the id. Hence the call

exometer_report:subscribe(Reporter,
                          [eradius, '127.0.0.1:8111', requests],
                          value, 500,
                          [{nas, {from_name, 2}}],
                          true).

will use the metrics name 'eradius_requests' and the tag pair
'{nas, '127.0.0.1:8111'}'. This works identically by using
'[{nas, {from_name, '127.0.0.1:8111'}}]'.
