### PR TITLE
Add auto subscriptions via module

### DIFF
--- a/test/exometer_influxdb_subscribe_mod.erl
+++ b/test/exometer_influxdb_subscribe_mod.erl
@@ -1,0 +1,13 @@
+-module(exometer_influxdb_subscribe_mod).
+-compile([export_all]).
+
+subscribe([metric, test], histogram) ->
+   Tags = [{tags, [{type, {from_name, 2}}]}],
+   [{[metric, test], min, 1000, Tags},
+    {[metric, test], max, 1000, Tags},
+    {[metric, test], median, 1000, Tags}];
+subscribe([metric, test1], histogram) ->
+   Tags = [{tags, [{type, {from_name, 2}}]}],
+   [{[metric, test1], max, 1000, Tags},
+    {[metric, test1], median, 1000, Tags}];
+subscribe(_, _) -> [].


### PR DESCRIPTION
This commit introduces feature for making subscription automatically for
each new entry. By default it is off. If you want to use auto
subscription you should turn it on in reporter options:

``` erlang
{exometer,
    {reporters, [
        {exometer_report_influxdb, [
            {autosubscribe, true},
            {subscriptions_module, exometer_influxdb_subscribe_mod},
            {protocol, http},
            {host, <<"localhost">>},
            {port, 8086},
            {db, <<"exometer">>},
            {tags, [{region, ru}]}
        ]}
    ]}
```

Module may look like:

``` erlang
-module(exometer_influxdb_subscribe_mod).
-compile([export_all]).

subscribe([metric, test], histogram) ->
    Tags = [{tags, [{type, {from_name, 2}}]}],
    [{[metric, test], min, 1000, Tags},
     {[metric, test], max, 1000, Tags},
     {[metric, test], median, 1000, Tags}];
subscribe([metric, test1], histogram) ->
    Tags = [{tags, [{type, {from_name, 2}}]}],
    [{[metric, test1], max, 1000, Tags},
     {[metric, test1], median, 1000, Tags}];
subscribe(_, _) -> [].
```

`subscribe/2` calls for each new entry and it should return list or just
one subscription.

Here subscription is:

``` erlang
 {exometer_report:metric(),
  exometer_report:datapoint(),
  exometer_report:interval(),
  exometer_report:extra()}
```
