### PR TITLE
batch sending of multiple values with timestamping enabled

### DIFF
--- a/src/exometer_report_influxdb.erl
+++ b/src/exometer_report_influxdb.erl
@@ -264,6 +264,11 @@ maybe_send(OriginMetricName, MetricName, Tags0, Fields,
             maps:put(OriginMetricName, 
                      {MetricName, Tags, NewFields, Timestamping andalso unix_time(Precision)}, 
                      CollectedMetrics);
+        {MetricName, Tags, Fields1, _OrigTimestamp} ->
+            NewFields = maps:merge(Fields, Fields1),
+            maps:put(OriginMetricName,
+                     {MetricName, Tags, NewFields, Timestamping andalso unix_time(Precision)},
+                     CollectedMetrics);
         not_found -> 
             maps:put(OriginMetricName, 
                      {MetricName, Tags0, Fields, Timestamping andalso unix_time(Precision)}, 


### PR DESCRIPTION
Not sure if the title is clear enough, but I'll try to explain in more detail.

If both timestamping and batch_window_size is enabled (respectively true and something greater than zero) I get an error on `no case clause matching`

```
14:18:36.504 [error] CRASH REPORT Process exometer_report_influxdb with 0 neighbours crashed with reason: no case clause matching {[erlang,memory],#{<<"host">> => "timmov-mbp.local"},#{total => 50843616},1459513116503950} in exometer_report_influxdb:maybe_send/5 line 261
```

This happens when you define a metric as:

```
{ [:erlang, :memory], {:function, :erlang, :memory, [], :proplist, [:processes, :total]}, [] }]
```

And a subscription as:

```
{:exometer_report_influxdb, [:erlang, :memory], [:total, :processes], 5000, true, []}
```

This patch resets the timestamp so that for `[:erlang, :memory]` the timestamp is taken from the latest in the list (one of these: `[:total, :processes]`).

The result of this patch is this (ngrep):

```
erlang_memory,host=timmov-mbp.local processes=8878072i,total=51101328i 1459514976146610
```

Which I think is mentioned in https://github.com/travelping/exometer_influxdb/issues/14#issuecomment-194902675

Please let me know if this is acceptable.
