### PR TITLE
Fix compilation on Erlang 19 by updating rebar.config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ otp_release:
     - 18.0
     - 18.1
     - 18.2
+    - 19.0
 script: "rebar get-deps compile && rebar skip_deps=true eunit"

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,7 @@
 {deps, [
         {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {branch, "master"}}},
+        %% lager dependency to override exometer's lager dependency, which does not compile on Erlang 19.
+        {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.1"}}},
         {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core.git", "5fdd9426713a3c26cae32f644a3120711b1cdb64"}}
        ]}.
 {erl_opts, [{parse_transform, lager_transform}]}.

--- a/src/exometer_influxdb.app.src
+++ b/src/exometer_influxdb.app.src
@@ -7,6 +7,7 @@
                   kernel,
                   stdlib,
                   hackney,
+                  lager,
                   exometer_core
                  ]},
   {env, []}


### PR DESCRIPTION
The old exometer dependency had a lager dependency which did not compile on Erlang 19.

However, newer exometer versions do not have a lager dependency, so I had to add one manually, which fixed compilation on Erlang 19.
