### PR TITLE
Add ability to set `Retry' parameter to subscription from module

### DIFF
--- a/src/exometer_report_influxdb.erl
+++ b/src/exometer_report_influxdb.erl
@@ -327,8 +327,10 @@ merge_tags(Tags, AdditionalTags) -> maps:merge(Tags, AdditionalTags).
                           exometer_report:extra()}) -> ok.
 subscribe(Subscribtions) when is_list(Subscribtions) ->
     [subscribe(Subscribtion) || Subscribtion <- Subscribtions];
+subscribe({Name, DataPoint, Interval, Extra, Retry}) when is_boolean(Retry) ->
+    exometer_report:subscribe(?MODULE, Name, DataPoint, Interval, Extra, Retry);
 subscribe({Name, DataPoint, Interval, Extra}) ->
-    exometer_report:subscribe(?MODULE, Name, DataPoint, Interval, Extra, false);
+    exometer_report:subscribe(?MODULE, Name, DataPoint, Interval, Extra);
 subscribe(_Name) -> 
     [].
 

--- a/test/exometer_influxdb_subscribe_mod.erl
+++ b/test/exometer_influxdb_subscribe_mod.erl
@@ -2,12 +2,12 @@
 -compile([export_all]).
 
 subscribe([metric, test], histogram) ->
-   Tags = [{tags, [{type, {from_name, 2}}]}],
-   [{[metric, test], min, 1000, Tags},
-    {[metric, test], max, 1000, Tags},
-    {[metric, test], median, 1000, Tags}];
+    Extra = [{tags, [{type, {from_name, 2}}]}],
+    [{[metric, test], min, 1000, Extra},
+     {[metric, test], max, 1000, Extra},
+     {[metric, test], median, 1000, Extra}];
 subscribe([metric, test1], histogram) ->
-   Tags = [{tags, [{type, {from_name, 2}}]}],
-   [{[metric, test1], max, 1000, Tags},
-    {[metric, test1], median, 1000, Tags}];
+    Extra = [{tags, [{type, {from_name, 2}}]}],
+    [{[metric, test1], max, 1000, Extra, false},
+     {[metric, test1], median, 1000, Extra}];
 subscribe(_, _) -> [].

--- a/test/exometer_influxdb_test.erl
+++ b/test/exometer_influxdb_test.erl
@@ -1,6 +1,7 @@
 -module(exometer_influxdb_test).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("exometer_core/include/exometer.hrl").
 
 -import(exometer_report_influxdb, [evaluate_subscription_options/5,
                                    make_packet/5]).
@@ -126,6 +127,10 @@ subscribtions_module_test() ->
 
     timer:sleep(100),
     ?assertEqual(5, length(exometer_report:list_subscriptions(exometer_report_influxdb))),
+
+    Retries = [{Name ++ [DP], Retry} || {subscriber, {_, _, Name, DP, Retry, _}, _, _} <- ets:tab2list(?EXOMETER_SUBS)],
+    ?assertEqual(true, proplists:get_value([metric, test, median], Retries)),
+    ?assertEqual(false, proplists:get_value([metric, test1, max], Retries)),
 
     [application:stop(App) || App <- Apps],
     gen_udp:close(Socket),


### PR DESCRIPTION
from exometer documentation:
`Retry': boolean(). If true, retry the subscription at the next
interval, even if the metric cannot be read.

`true` by default
