### PR TITLE
Make `SubscribeOpts` optional

### DIFF
--- a/src/exometer_report_influxdb.erl
+++ b/src/exometer_report_influxdb.erl
@@ -466,6 +466,8 @@ del_indices1(_List, Indices) ->
 
 -spec evaluate_subscription_options(list(), [{atom(), value()}], map(), atom(), [{atom(), value()}])
                                     -> {list() | atom(), map()}.
+evaluate_subscription_options(MetricId, undefined, DefaultTags, DefaultSeriesName, DefaultFormatting) ->
+  evaluate_subscription_options(MetricId, [], DefaultTags, DefaultSeriesName, DefaultFormatting);
 evaluate_subscription_options(MetricId, Options, DefaultTags, DefaultSeriesName, DefaultFormatting) ->
     TagOpts = proplists:get_value(tags, Options, []),
     TagsResult = evaluate_subscription_tags(MetricId, TagOpts),


### PR DESCRIPTION
The InfluxDB reporter crashes when a subscription is
configured without `SubscribeOpts`.  Making that term
optional allows consumers to configure subscriptions
statically without customized tags, e.g.:

```
{exometer_report_influxdb, [thing, count], value, 1000}
```
