### PR TITLE
Does not show password in log

### DIFF
--- a/src/exometer_report_influxdb.erl
+++ b/src/exometer_report_influxdb.erl
@@ -248,7 +248,7 @@ reconnect(#state{protocol = Protocol, host = Host, port = Port,
     case connect(Protocol, Host, Port, Username, Password) of
         {ok, Connection} ->
             ?info("InfluxDB reporter reconnecting success: ~p",
-                  [{Protocol, Host, Port, Username, Password}]),
+                  [{Protocol, Host, Port, Username}]),
             {ok, State#state{connection = Connection}};
         Error ->
             ?error("InfluxDB reporter reconnecting error: ~p", [Error]),


### PR DESCRIPTION
Sometimes it is not a good idea to show password of database in logs.
I think it would better to hide it.

looking froward feedback. 

have a nice day!