### PR TITLE
Add node() as additional tag just like host

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Available options:
 
 The following options can be set globally in the reporter config or locally in a specific subscription. The latter case overwrites the first.
 
-* __tags__ - List of tags for each time series. The `host` is automatically included here.
+* __tags__ - List of tags for each time series. The `host` and `node` are automatically included here.
 * __series_name__ - The name of a time series visible within the `FROM` field. By default this is set to the concatenated elements of the exometer id. Caution: If set in the global reporter config then every time series will have this name.
 * __formatting__ - Formatting options to alter the appearance of a series name or tags.
 

--- a/src/exometer_report_influxdb.erl
+++ b/src/exometer_report_influxdb.erl
@@ -87,7 +87,7 @@ exometer_init(Opts) ->
     Formatting = get_opt(formatting, Opts, ?DEFAULT_FORMATTING),
     Autosubscribe = get_opt(autosubscribe, Opts, ?DEFAULT_AUTOSUBSCRIBE),
     SubscriptionsMod = get_opt(subscriptions_module, Opts, ?DEFAULT_SUBSCRIPTIONS_MOD),
-    MergedTags = merge_tags([{<<"host">>, net_adm:localhost()}], Tags),
+    MergedTags = merge_tags([{<<"host">>, net_adm:localhost()}, {<<"node">>, node()}], Tags),
     State =  #state{protocol = Protocol,
                     db = DB,
                     username = Username,


### PR DESCRIPTION
Since it's more and more common to run multiple Erlang VM's on the same host, it'd be nice to add `node()` as an additional tag. For metrics that I control, this is easy but it seems to be more tricky for `predefined` metrics like Erlang VM stats. 

Perhaps I'm missing something? 

Opening this PR to see if you'd be open for this thing, if so, I can explore ways of adding `node()` as an optional tag :) 